### PR TITLE
Fix for #26 - indexing of queued items

### DIFF
--- a/jquery.poptrox.js
+++ b/jquery.poptrox.js
@@ -619,6 +619,14 @@
 
 					});
 
+				function createImageOnClickHandler(index) {
+				    return function(e) {
+					    e.preventDefault();
+					    e.stopPropagation();
+					    $popup.trigger('poptrox_open', [index]);
+				    };
+				}
+
 				$this.find(settings.selector).each(function(index) {
 
 					var x, tmp, a = $(this), i = a.find('img'), data = a.data('poptrox');
@@ -860,7 +868,7 @@
 							e.preventDefault();
 							e.stopPropagation();
 
-							$popup.trigger('poptrox_open', [queue.length-1]);
+							$popup.trigger('poptrox_open', createImageOnClickHandler(queue.length-1));
 
 						});
 

--- a/jquery.poptrox.js
+++ b/jquery.poptrox.js
@@ -860,7 +860,7 @@
 							e.preventDefault();
 							e.stopPropagation();
 
-							$popup.trigger('poptrox_open', [index]);
+							$popup.trigger('poptrox_open', [queue.length-1]);
 
 						});
 

--- a/jquery.poptrox.js
+++ b/jquery.poptrox.js
@@ -863,14 +863,7 @@
 					a
 						.attr('href', '')
 						.css('outline', 0)
-						.on('click', function(e) {
-
-							e.preventDefault();
-							e.stopPropagation();
-
-							$popup.trigger('poptrox_open', createImageOnClickHandler(queue.length-1));
-
-						});
+						.on('click', createImageOnClickHandler(queue.length-1));
 
 				});
 


### PR DESCRIPTION
The problem is that marking anchor as ignored results in not adding it
to the images queue, hence the queue is shorter than total number of
images. The initial processing goes through images and creates a
function that trigger opening an image by its initial index, but the
index is different in the queue due to ignored images.
